### PR TITLE
In Control

### DIFF
--- a/config/incontrol/loot.json
+++ b/config/incontrol/loot.json
@@ -1,1 +1,8 @@
-[]
+[
+	{
+		"dimension": 0,
+		"hostile": true,
+		"random": 0.66,
+		"item": "scrap:scrap"	
+	}
+]

--- a/config/incontrol/spawn.json
+++ b/config/incontrol/spawn.json
@@ -2,7 +2,7 @@
 	{
 		"dimension": 0,
 		"hostile": true,		
-		"result": deny
+		"result": "deny"
 	},
 	{
 		"dimension": 0,

--- a/config/incontrol/spawn.json
+++ b/config/incontrol/spawn.json
@@ -1,1 +1,13 @@
-[]
+[
+	{
+		"dimension": 0,
+		"hostile": true,		
+		"result": deny
+	},
+	{
+		"dimension": 0,
+		"hostile": true,
+		"incity": true,
+		"result": "default"		
+	}
+]


### PR DESCRIPTION
Adds Scripts for In Control to limit spawning in the Overworld to Lost Cities only. We may need to add an exception for guardians in the Ocean.

Added scripts for In Control to have hostile mobs, in the Overworld, drop Scrap. Currently does not check if the mob is in a city because they may wander out. Current drop chance is about 2/3rds of the time for testing. We need a better number before release