### PR TITLE
Config Updates for 1.0.1

### DIFF
--- a/config/incontrol/loot.json
+++ b/config/incontrol/loot.json
@@ -4,7 +4,7 @@
 		"dimension": 0,
 		"hostile": true,
 		"random": 0.66,
-		"item": "scrap:scrap/{TABLE:\"scrap:scrap\",PLATE:\"d1a77f\",GEAR:\"d0c2ba\",NAME:\"Parts\"}"
+		"item": "scrap:scrap/{TABLE:\"scrap:scrap\",PLATE:\"d1a77f\",GEAR:\"d0c2ba\",NAME:\"Parts\",XP:\"3d4\"}"
 	},
 	{
 		"player": true,
@@ -13,6 +13,6 @@
 		"incity": true,
 		"minheight": 50,
 		"random":0.1,
-		"item": "scrap:scrap/{TABLE:\"scrap:chest\",PLATE:\"269463\",GEAR:\"ab948b\",NAME:\"City Chest\"}"
+		"item": "scrap:scrap/{TABLE:\"scrap:chest\",PLATE:\"269463\",GEAR:\"ab948b\",NAME:\"City Chest\",XP:\"4d8\"}"
 	}
 ]

--- a/config/incontrol/spawn.json
+++ b/config/incontrol/spawn.json
@@ -1,5 +1,3 @@
 [
-	{ "dimension": 0, "hostile": true, "incity": true, "result": "default" },
-	{ "maxheight": 59, "dimension": 0, "hostile": true, "seesky": false, "result": "default" },
-	{ "dimension": 0, "hostile": true, "result": "deny"}
+	{ "dimension": 0, "hostile": true, "minheight": 60, "incity": false, "result": "deny"}
 ]

--- a/config/scrap.cfg
+++ b/config/scrap.cfg
@@ -12,8 +12,8 @@ general {
 
     # Each table below will have a bag generated for it. Only put one entry per line in the format of 'name@xp@domain:path@GearColor@PlateColor' with no commas. You can omit one or both of the Color Options to use defaults. Using a Single color will result in both the gear and plate being the same tint. XP is award in Dice notation. For example 2d6 would roll 2 6-sided dice and return the results. Anywhere from 2 to 12
     S:loot_tables <
-        Parts@scrap:scrap
-        City Chest@scrap:chest@ab948b@269463
+        Parts@scrap:scrap@3d4
+        City Chest@scrap:chest@4d8@ab948b@269463
      >
 
     # Enable Opening a stack of Scrap at a time when Sneaking. Watchout for overflow

--- a/scripts/AE2.zs
+++ b/scripts/AE2.zs
@@ -1,0 +1,62 @@
+recipes.remove(<appliedenergistics2:quantum_ring>);
+recipes.addShaped("CTQuantumRing", <appliedenergistics2:quantum_ring>,
+[	[<ore:ingotIron>,<appliedenergistics2:material:22>,<ore:ingotIron>],
+	[<appliedenergistics2:material:24>,<appliedenergistics2:energy_cell>,<appliedenergistics2:part:36>],
+	[<ore:ingotIron>,<appliedenergistics2:material:22>,<ore:ingotIron>]]);
+
+//Lets remove the stub recipes for the Dense Cable and Smart Cable too
+
+recipes.remove(<appliedenergistics2:part:40>);
+recipes.remove(<appliedenergistics2:part:41>);
+recipes.remove(<appliedenergistics2:part:42>);
+recipes.remove(<appliedenergistics2:part:43>);
+recipes.remove(<appliedenergistics2:part:44>);
+recipes.remove(<appliedenergistics2:part:45>);
+recipes.remove(<appliedenergistics2:part:46>);
+recipes.remove(<appliedenergistics2:part:47>);
+recipes.remove(<appliedenergistics2:part:48>);
+recipes.remove(<appliedenergistics2:part:49>);
+recipes.remove(<appliedenergistics2:part:50>);
+recipes.remove(<appliedenergistics2:part:51>);
+recipes.remove(<appliedenergistics2:part:52>);
+recipes.remove(<appliedenergistics2:part:53>);
+recipes.remove(<appliedenergistics2:part:54>);
+recipes.remove(<appliedenergistics2:part:55>);
+recipes.remove(<appliedenergistics2:part:56>);
+
+recipes.remove(<appliedenergistics2:part:60>);
+recipes.remove(<appliedenergistics2:part:61>);
+recipes.remove(<appliedenergistics2:part:62>);
+recipes.remove(<appliedenergistics2:part:63>);
+recipes.remove(<appliedenergistics2:part:64>);
+recipes.remove(<appliedenergistics2:part:65>);
+recipes.remove(<appliedenergistics2:part:66>);
+recipes.remove(<appliedenergistics2:part:67>);
+recipes.remove(<appliedenergistics2:part:68>);
+recipes.remove(<appliedenergistics2:part:69>);
+recipes.remove(<appliedenergistics2:part:70>);
+recipes.remove(<appliedenergistics2:part:71>);
+recipes.remove(<appliedenergistics2:part:72>);
+recipes.remove(<appliedenergistics2:part:73>);
+recipes.remove(<appliedenergistics2:part:74>);
+recipes.remove(<appliedenergistics2:part:75>);
+recipes.remove(<appliedenergistics2:part:76>);
+
+recipes.remove(<appliedenergistics2:part:500>);
+recipes.remove(<appliedenergistics2:part:501>);
+recipes.remove(<appliedenergistics2:part:502>);
+recipes.remove(<appliedenergistics2:part:503>);
+recipes.remove(<appliedenergistics2:part:504>);
+recipes.remove(<appliedenergistics2:part:505>);
+recipes.remove(<appliedenergistics2:part:506>);
+recipes.remove(<appliedenergistics2:part:507>);
+recipes.remove(<appliedenergistics2:part:508>);
+recipes.remove(<appliedenergistics2:part:509>);
+recipes.remove(<appliedenergistics2:part:510>);
+recipes.remove(<appliedenergistics2:part:511>);
+recipes.remove(<appliedenergistics2:part:512>);
+recipes.remove(<appliedenergistics2:part:513>);
+recipes.remove(<appliedenergistics2:part:514>);
+recipes.remove(<appliedenergistics2:part:515>);
+recipes.remove(<appliedenergistics2:part:516>);
+


### PR DESCRIPTION
Simplied InControl Spawning Rules.
Updated InControl Loot Rules to give Scrap with XP
Update Scrap Config to include XP
Removed erroneous AE2 Recipes caused by disabling channels
Added Recipe for Quantum Ring. Covered Fluix Cable replaces the bad
dense cable.