### PR TITLE
Loot and Juice for 1.0.2

### DIFF
--- a/config/incontrol/loot.json
+++ b/config/incontrol/loot.json
@@ -1,6 +1,6 @@
 [
-	{
-		"player": true,
+	{		
+		"realplayer": true,
 		"dimension": 0,
 		"hostile": true,
 		"incity": true,
@@ -9,12 +9,30 @@
 		"item": "scrap:scrap/{TABLE:\"scrap:scrap\",PLATE:\"d1a77f\",GEAR:\"d0c2ba\",NAME:\"Parts\",XP:\"3d4\"}"
 	},
 	{
-		"player": true,
+		"realplayer": true,
 		"dimension": 0,
 		"hostile": true,
 		"incity": true,
 		"minheight": 50,
 		"random":0.1,
+		"item": "scrap:scrap/{TABLE:\"scrap:chest\",PLATE:\"269463\",GEAR:\"ab948b\",NAME:\"City Chest\",XP:\"4d8\"}"
+	},
+	{
+		"fakeplayer": true,
+		"dimension": 0,
+		"hostile": true,
+		"incity": true,
+		"minheight": 50,
+		"random": 0.167,
+		"item": "scrap:scrap/{TABLE:\"scrap:scrap\",PLATE:\"d1a77f\",GEAR:\"d0c2ba\",NAME:\"Parts\",XP:\"3d4\"}"
+	},
+	{
+		"fakeplayer": true,
+		"dimension": 0,
+		"hostile": true,
+		"incity": true,
+		"minheight": 50,
+		"random":0.025,
 		"item": "scrap:scrap/{TABLE:\"scrap:chest\",PLATE:\"269463\",GEAR:\"ab948b\",NAME:\"City Chest\",XP:\"4d8\"}"
 	}
 ]

--- a/scripts/ThermalFoundation.zs
+++ b/scripts/ThermalFoundation.zs
@@ -1,5 +1,6 @@
 import crafttweaker.item.IItemStack;
 import mods.thermalexpansion.Pulverizer;
+import mods.thermalexpansion.Refinery;
 
 //RF Cost to Pulverize Plates and Gears back to Dust
 val RFCOST = 1500 as int;
@@ -16,5 +17,7 @@ mods.thermalexpansion.Pulverizer.addRecipe(dust * 4, foundationGears[i], RFCOST,
 }
 
 //Essence to Experience conversion
+mods.thermalexpansion.Refinery.addRecipe(<liquid:essence> * 100, null,<liquid:experience> * 100, 2500);
+mods.thermalexpansion.Refinery.addRecipe(<liquid:experience> * 100, null,<liquid:essence> * 100, 2500);
 
 

--- a/scripts/ThermalFoundation.zs
+++ b/scripts/ThermalFoundation.zs
@@ -15,4 +15,6 @@ mods.thermalexpansion.Pulverizer.addRecipe(dust, foundationPlates[i], RFCOST);
 mods.thermalexpansion.Pulverizer.addRecipe(dust * 4, foundationGears[i], RFCOST, <minecraft:iron_ingot>, 20);
 }
 
+//Essence to Experience conversion
+
 


### PR DESCRIPTION
Updated In Control! loot json to make drops slightly rarer for fake players.

By default Parts drop 4 per 6 kills for players and 1 per 6 kills for fake players.

City loot drops 4 per 40 kills for players and 1 per 40 kills per fake player.

Add recipes to convert Essence from IF and Experience from TE back and forth. 