### PR TITLE
Corrected Scrap Loot Colors

### DIFF
--- a/config/scrap.cfg
+++ b/config/scrap.cfg
@@ -10,10 +10,10 @@ general {
     # Enables Dented Plates
     B:enableBrokenPlates=false
 
-    # Each table below will have a bag generated for it. Only put one entry per line in the format of 'name@xp@domain:path@GearColor@PlateColor' with no commas. You can omit one or both of the Color Options to use defaults. Using a Single color will result in both the gear and plate being the same tint. XP is award in Dice notation. For example 2d6 would roll 2 6-sided dice and return the results. Anywhere from 2 to 12
+    # Each table below will have a bag generated for it. Only put one entry per line in the format of 'name@domain:path@xp@#GearColor@#PlateColor' with no commas. You can omit one or both of the Color Options to use defaults. Using a Single color will result in both the gear and plate being the same tint. XP is award in Dice notation. For example 2d6 would roll 2 6-sided dice and return the results. Anywhere from 2 to 12
     S:loot_tables <
         Parts@scrap:scrap@3d4
-        City Chest@scrap:chest@4d8@ab948b@269463
+        City Chest@scrap:chest@4d8@#ab948b@#269463
      >
 
     # Enable Opening a stack of Scrap at a time when Sneaking. Watchout for overflow


### PR DESCRIPTION
Without the #, new scrap would use default colors. Existing was
unaffected as were those dropped by InControl. Primarily affects JEI and creative